### PR TITLE
fix(typo): fix a typo 'CONF=CONF=k230_canmv_defconfig'

### DIFF
--- a/en/01_software/board/K230_SDK_Instructions.md
+++ b/en/01_software/board/K230_SDK_Instructions.md
@@ -284,7 +284,7 @@ make CONF=k230_evb_defconfig  #compile K230-USIP-LP3-EVB image
 > - Compile the K230-USIP-LP3-EVB board image using the`make CONF=k230_evb_defconfig`  command.
 > - Compile the K230-SIP-LP3-EVB board image using the`make CONF=k230d_defconfig`  command.
 > - Compile the nand image of the K230-USIP-LP3-EVB board using the `make CONF=k230_evb_nand_defconfig`  command
-> - Compile the image of the CanMV-K230 board using the `make CONF=CONF=k230_canmv_defconfig`  command
+> - Compile the image of the CanMV-K230 board using the `make CONF=k230_canmv_defconfig`  command
 >
 > Remark:
 The SDK does not support multi-process compilation, do not add multi-process compilation parameters like -j32.

--- a/zh/01_software/board/K230_SDK_使用说明.md
+++ b/zh/01_software/board/K230_SDK_使用说明.md
@@ -285,7 +285,7 @@ make CONF=k230_evb_defconfig  #编译K230-USIP-LP3-EVB板子镜像
 > - 编译K230-USIP-LP3-EVB板子镜像使用`make CONF=k230_evb_defconfig`  命令。
 > - 编译K230-SIP-LP3-EVB板子镜像使用`make CONF=k230d_defconfig`  命令。
 > - 编译K230-USIP-LP3-EVB板子的nand镜像使用 `make CONF=k230_evb_nand_defconfig`  命令
-> - 编译CanMV-K230板子的镜像使用 `make CONF=CONF=k230_canmv_defconfig`  命令
+> - 编译CanMV-K230板子的镜像使用 `make CONF=k230_canmv_defconfig`  命令
 >
 > 备注：
 sdk不支持多进程编译，不要增加类似-j32多进程编译参数。


### PR DESCRIPTION
# 发现文档错误

## 无关联issue
